### PR TITLE
Bump Rust version to 1.66.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         toolchain:
           - "stable"
           - "beta"
-          - "1.65.0"
+          - "1.66.1"
 
           # See https://rust-lang.github.io/rustup-components-history/ and choose
           # the newest nightly build that has all the components (except RLS,


### PR DESCRIPTION
This fixes a security vulnerability in cargo.